### PR TITLE
Get names of all S3 methods

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -44,7 +44,7 @@ extract_api <- function(path = ".", targets = character()) {
 
       exports <- ls(env$.__NAMESPACE__.$exports, all.names = TRUE)
 
-      s3_methods <- ls(env$.__S3MethodsTable__., all.names = TRUE)
+      s3_methods <- env$.__NAMESPACE__.$S3methods[, 3]
 
       imports <- eapply(
         pkgload::imports_env(name),


### PR DESCRIPTION
including those defined elsewhere. Fixes #16.

Example: https://github.com/krlmlr/utf8/commit/f013d095e05aae57a6bf87bed2c2888977d6560d.