### PR TITLE
fix usethis call

### DIFF
--- a/R/roclet.R
+++ b/R/roclet.R
@@ -37,7 +37,7 @@ roclet_output.roclet_api <- function(x, results, base_path, ...) {
   # FIXME: write_if_different()
   writeLines(results, API)
 
-  usethis::use_build_ignore(file_name, base_path = base_path)
+  usethis::use_build_ignore(file_name)
 
   API
 }


### PR DESCRIPTION
In the release notes of `usethis` 1.0, it says
> The concept of the working directory and the "base path" have been refined.  Rather than using an argument to specify the active project, all use_ functions now use a global active project setting, as returned by `proj_get()`.

For this reason, with a usethis version >= 1.0.0, I get an error when running `roclet_output.roclet_api()`.
```
Error in usethis::use_build_ignore(file_name, base_path = base_path) : 
  unused argument (base_path = base_path)
```

This PR fixes the `usethis` call by dropping the `base_path` argument.